### PR TITLE
Publish an external oracle priceAuthority to the chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,8 @@ If you want to publish a scheduled query on the chain:
    the push `queryId`.  For prices in `"Testnet.$USD"` be sure to scale the
    resulting floating point dollar value up to mills (multiply by 1000)
    
-For Chainlink, ensure your `"request_id"` param is set to the `queryId` and use
-the Agoric external adapter to submit your job's results.
-
-As an example:
+An at example for Chainlink, ensure your `"request_id"` param is set to the
+`queryId` and use the Agoric external adapter to submit your job's results:
 
 ```json
 {
@@ -140,7 +138,8 @@ input issuer, you can create a price authority from it.
 
 1. Find out your wallet petnames for the input and output issuers (for example,
    `"Testnet.$LINK"` to `"Testnet.$USD"`).
-2. Create a public price authority for your push query:
+2. Create a public price authority for your push query (you will need to push at
+   least one result):
 ```sh
 NOTIFIER_BOARD_ID=<boardId of push notifier> \
 IN_ISSUER_JSON='"Testnet.$LINK"' OUT_ISSUER_JSON='"Testnet.$USD"' \
@@ -153,6 +152,17 @@ agoric deploy --hostport=127.0.0.1:7999 api/from-notifier.js
 PRICE_AUTHORITY_BOARD_ID=<boardId of price authority> \
 IN_ISSUER_JSON='"Testnet.$LINK"' OUT_ISSUER_JSON='"Testnet.$USD"' \
 agoric deploy --hostport=127.0.0.1:7999 api/register.js
+```
+
+Here is a session testing the `priceAuthority`:
+
+```js
+home.wallet~.getIssuer('Testnet.$LINK')~.getBrand()
+history[3] [Alleged: presence o-82]{}
+home.wallet~.getIssuer('Testnet.$USD')~.getBrand()
+history[4] = [Alleged: presence o-81]{}
+home.priceAuthority~.getQuoteNotifier(history[3], history[4])~.getUpdateSince()
+> {"value":{"quotePayment":[Promise],"quoteAmount":{"brand":[Alleged: presence o-132]{},"value":[{"amountIn":{"brand":[Alleged: presence o-82]{},"value":1000000},"amountOut":{"brand":[Alleged: presence o-81]{},"value":1191},"timer":[Alleged: presence o-68]{},"timestamp":1604759700}]}},"updateCount":2}
 ```
 
 ## Single-query Usage

--- a/README.md
+++ b/README.md
@@ -87,6 +87,74 @@ Go to the oracle server page at http://localhost:3000?API_PORT=7999
 
 Go to the oracle query page at http://localhost:3000
 
+### Publishing a scheduled query
+
+If you want to publish a scheduled query on the chain:
+
+1. Create a push query in the dapp-oracle server page.
+2. Create an external oracle job that posts back to Agoric with the results and
+   the push `queryId`.  For prices in `"Testnet.$USD"` be sure to scale the
+   resulting floating point dollar value up to mills (multiply by 1000)
+   
+For Chainlink, ensure your `"request_id"` param is set to the `queryId` and use
+the Agoric external adapter to submit your job's results.
+
+As an example:
+
+```json
+{
+  "initiators": [
+    {
+      "type": "cron",
+      "params": {
+          "schedule": "CRON_TZ=UTC */10 * * *"
+      }
+    }
+  ],
+  "tasks": [
+    {
+      "type": "HTTPGet",
+      "confirmations": 0,
+      "params": { "get": "https://bitstamp.net/api/ticker/" }
+    },
+    {
+      "type": "JSONParse",
+      "params": { "path": [ "last" ] }
+    },
+    {
+      "type": "Multiply",
+      "params": { "times": 1000 }
+    },
+    {
+      "type": "Agoric",
+      "params": { "request_id": "<your queryId>" }
+    }
+  ]
+}
+```
+
+### Publishing a price authority
+
+If your scheduled query returns a numeric string as the price of a unit of your
+input issuer, you can create a price authority from it.
+
+1. Find out your wallet petnames for the input and output issuers (for example,
+   `"Testnet.$LINK"` to `"Testnet.$USD"`).
+2. Create a public price authority for your push query:
+```sh
+NOTIFIER_BOARD_ID=<boardId of push notifier> \
+IN_ISSUER_JSON='"Testnet.$LINK"' OUT_ISSUER_JSON='"Testnet.$USD"' \
+agoric deploy --hostport=127.0.0.1:7999 api/from-notifier.js
+```
+3. Publish the resulting `PRICE_AUTHORITY_BOARD_ID` to the on-chain
+   `agoric.priceAuthority`.  If you want to publish to the testnet you will need
+   to ask for somebody privileged to do this for you.
+```sh
+PRICE_AUTHORITY_BOARD_ID=<boardId of price authority> \
+IN_ISSUER_JSON='"Testnet.$LINK"' OUT_ISSUER_JSON='"Testnet.$USD"' \
+agoric deploy --hostport=127.0.0.1:7999 api/register.js
+```
+
 ## Single-query Usage
 
 The `E(publicFacet).makeQueryInvitation(query)` call creates a query invitation,

--- a/api/from-notifier.js
+++ b/api/from-notifier.js
@@ -97,7 +97,7 @@ export default async function priceAuthorityfromNotifier(
     console.log('Stored priceAuthorityFactory in scratch');
   }
 
-  console.log('Waiting for first valid quote from notifier...');
+  console.log('Waiting for first valid quote from push notifier...');
   const priceAuthority = await E(
     priceAuthorityFactory,
   ).makeNotifierPriceAuthority({

--- a/api/from-notifier.js
+++ b/api/from-notifier.js
@@ -1,0 +1,113 @@
+// @ts-check
+import { E } from '@agoric/eventual-send';
+import '@agoric/zoe/exported';
+import '@agoric/zoe/src/contracts/exported';
+
+/**
+ * @typedef {Object} DeployPowers The special powers that `agoric deploy` gives us
+ * @property {(path: string) => Promise<{ moduleFormat: string, source: string }>} bundleSource
+ * @property {(path: string) => string} pathResolve
+ * @property {(path: string, opts?: any) => Promise<any>} installUnsafePlugin
+ * @property {string} host
+ * @property {string} port
+ *
+ * @typedef {Object} Board
+ * @property {(id: string) => any} getValue
+ * @property {(value: any) => string} getId
+ * @property {(value: any) => boolean} has
+ * @property {() => [string]} ids
+ */
+
+/**
+ * @typedef {{ board: Board, chainTimerService, wallet, scratch, spawner }} Home
+ * @param {Promise<Home>} homePromise
+ * A promise for the references available from REPL home
+ */
+export default async function priceAuthorityfromNotifier(
+  homePromise,
+  { bundleSource, pathResolve },
+) {
+  const {
+    FORCE_SPAWN = 'true',
+    IN_ISSUER_JSON = JSON.stringify('Testnet.$LINK'),
+    OUT_ISSUER_JSON = JSON.stringify('Testnet.$USD'),
+    NOTIFIER_BOARD_ID,
+  } = process.env;
+
+  if (!NOTIFIER_BOARD_ID) {
+    console.error(`You must specify PRICE_AUTHORITY_BOARD_ID`);
+    process.exit(1);
+  }
+
+  // Let's wait for the promise to resolve.
+  const home = await homePromise;
+
+  // Unpack the references.
+  const { board, scratch, wallet, spawner, chainTimerService: timer } = home;
+
+  const issuersArray = await E(wallet).getIssuers();
+  const issuerNames = issuersArray.map(([petname]) => JSON.stringify(petname));
+  const issuerIn = await E(wallet).getIssuer(JSON.parse(IN_ISSUER_JSON));
+  const issuerOut = await E(wallet).getIssuer(JSON.parse(OUT_ISSUER_JSON));
+
+  if (issuerIn === undefined) {
+    console.error(
+      'Cannot find IN_ISSUER_JSON',
+      IN_ISSUER_JSON,
+      'in home.wallet',
+    );
+    console.error('Have issuers:', issuerNames.join(', '));
+    process.exit(1);
+  }
+
+  if (issuerOut === undefined) {
+    console.error(
+      'Cannot find OUT_ISSUER_JSON',
+      OUT_ISSUER_JSON,
+      'in home.wallet',
+    );
+    console.error('Have issuers:', issuerNames.join(', '));
+    process.exit(1);
+  }
+
+  const displayInfo = await E(E(issuerIn).getBrand()).getDisplayInfo();
+  const { decimalPlaces = 0 } = displayInfo || {};
+
+  const unitValueIn = 10 ** decimalPlaces;
+
+  // Get the notifier.
+  const notifierId = NOTIFIER_BOARD_ID.replace(/^board:/, '');
+  const notifier = E(board).getValue(notifierId);
+
+  let priceAuthorityFactory = E(scratch).get('priceAuthorityFactory');
+
+  if (FORCE_SPAWN || !priceAuthorityFactory) {
+    // Bundle up the notifierPriceAuthority code
+    const bundle = await bundleSource(
+      pathResolve('./src/priceAuthorityFactory.js'),
+    );
+
+    // Install it on the spawner
+    const notifierFactory = E(spawner).install(bundle);
+
+    // Spawn the running code
+    priceAuthorityFactory = await E(notifierFactory).spawn();
+
+    await E(scratch).set('priceAuthorityFactory', priceAuthorityFactory);
+    console.log('Stored priceAuthorityFactory in scratch');
+  }
+
+  console.log('Waiting for first valid quote from notifier...');
+  const priceAuthority = await E(
+    priceAuthorityFactory,
+  ).makeNotifierPriceAuthority({
+    notifier,
+    issuerIn,
+    issuerOut,
+    timer,
+    unitValueIn,
+  });
+
+  const PRICE_AUTHORITY_BOARD_ID = await E(board).getId(priceAuthority);
+  console.log('-- PRICE_AUTHORITY_BOARD_ID:', PRICE_AUTHORITY_BOARD_ID);
+}

--- a/api/register.js
+++ b/api/register.js
@@ -1,0 +1,86 @@
+// @ts-check
+import { E } from '@agoric/eventual-send';
+import '@agoric/zoe/exported';
+import '@agoric/zoe/src/contracts/exported';
+
+/**
+ * @typedef {Object} Board
+ * @property {(id: string) => any} getValue
+ * @property {(value: any) => string} getId
+ * @property {(value: any) => boolean} has
+ * @property {() => [string]} ids
+ */
+
+/**
+ * @typedef {{ zoe: ZoeService, board: Board, wallet, scratch, priceAuthorityAdmin }} Home
+ * @param {Promise<Home>} homePromise
+ * A promise for the references available from REPL home
+ */
+export default async function registerPriceAuthority(homePromise) {
+  const {
+    IN_ISSUER_JSON = JSON.stringify('Testnet.$LINK'),
+    OUT_ISSUER_JSON = JSON.stringify('Testnet.$USD'),
+    PRICE_AUTHORITY_BOARD_ID,
+  } = process.env;
+
+  if (!PRICE_AUTHORITY_BOARD_ID) {
+    console.error(`You must specify PRICE_AUTHORITY_BOARD_ID`);
+    process.exit(1);
+  }
+
+  // Let's wait for the promise to resolve.
+  const home = await homePromise;
+
+  // Unpack the references.
+  const { board, priceAuthorityAdmin, scratch, wallet } = home;
+
+  if (!priceAuthorityAdmin) {
+    console.error(
+      `You need to ask somebody with "agoric.priceAuthorityAdmin" power to run this command.`,
+    );
+    process.exit(1);
+  }
+
+  const priceAuthorityId = PRICE_AUTHORITY_BOARD_ID.replace(/^board:/, '');
+  const priceAuthority = E(board).getValue(priceAuthorityId);
+
+  const issuersArray = await E(wallet).getIssuers();
+  const issuerNames = issuersArray.map(([petname]) => JSON.stringify(petname));
+  const issuerIn = await E(wallet).getIssuer(JSON.parse(IN_ISSUER_JSON));
+  const issuerOut = await E(wallet).getIssuer(JSON.parse(OUT_ISSUER_JSON));
+
+  if (issuerIn === undefined) {
+    console.error(
+      'Cannot find IN_ISSUER_JSON',
+      IN_ISSUER_JSON,
+      'in home.wallet',
+    );
+    console.error('Have issuers:', issuerNames.join(', '));
+    process.exit(1);
+  }
+
+  if (issuerOut === undefined) {
+    console.error(
+      'Cannot find OUT_ISSUER_JSON',
+      OUT_ISSUER_JSON,
+      'in home.wallet',
+    );
+    console.error('Have issuers:', issuerNames.join(', '));
+    process.exit(1);
+  }
+
+  const brandIn = await E(issuerIn).getBrand();
+  const brandOut = await E(issuerOut).getBrand();
+  const deleter = await E(priceAuthorityAdmin).registerPriceAuthority(
+    priceAuthority,
+    brandIn,
+    brandOut,
+    true,
+  );
+
+  const DELETER_NAME = `delete ${IN_ISSUER_JSON}-${OUT_ISSUER_JSON}`;
+  await E(scratch).set(DELETER_NAME, deleter);
+
+  console.log(`Delete this registration with:`);
+  console.log(`home.scratch~.get(${JSON.stringify(DELETER_NAME)})~.delete()`);
+}

--- a/api/src/asyncIterableKit.js
+++ b/api/src/asyncIterableKit.js
@@ -1,0 +1,89 @@
+// @ts-check
+import { E } from '@agoric/eventual-send';
+import {
+  makeNotifierKit,
+  makeAsyncIterableFromNotifier,
+} from '@agoric/notifier';
+
+import '@agoric/zoe/exported';
+
+/**
+ * @callback CancelFunction
+ * @param {any} [reason]
+ * @returns {void}
+ */
+
+/**
+ * @template T
+ * @typedef {Object} AsyncIterableKit
+ * @property {AsyncIterable<T>} asyncIterable
+ * @property {CancelFunction} cancel
+ */
+
+/**
+ * Create an async iterable that plays back a script.
+ *
+ * @template T
+ * @param {Array<T>} script
+ * @param {AsyncIterable<Timestamp>} timerAsyncIterable
+ * @param {ERef<TimerService>} timerP
+ * @param {boolean} [repeat=true]
+ * @returns {AsyncIterable<{ timer: TimerService, timestamp: Timestamp, item: T }>}
+ */
+export async function* makeScriptedAsyncIterable(
+  script,
+  timerAsyncIterable,
+  timerP,
+  repeat = true,
+) {
+  let index = 0;
+  const timer = await timerP;
+  for await (const timestamp of timerAsyncIterable) {
+    yield { timer, timestamp, item: script[index] };
+    index += 1;
+    if (index >= script.length) {
+      if (!repeat) {
+        return;
+      }
+      index = 0;
+    }
+  }
+}
+
+/**
+ * Create an asyncIterable kit from a timer repeater.
+ *
+ * @param {ERef<TimerRepeater>} repeater
+ * @param {Timestamp} [initialTimestamp]
+ * @returns {Promise<AsyncIterableKit<Timestamp>>}
+ */
+export const makeRepeaterAsyncIterableKit = async (
+  repeater,
+  initialTimestamp = undefined,
+) => {
+  /** @type {NotifierRecord<Timestamp>} */
+  const { notifier, updater } = makeNotifierKit();
+
+  if (initialTimestamp !== undefined) {
+    // Prime the pump.
+    updater.updateState(initialTimestamp);
+  }
+
+  /** @type {TimerWaker} */
+  await E(repeater).schedule({
+    // FIXME: It's a limit of the current API that we have no way to detect when a
+    // repeater has been disabled from within a handler.
+    wake(timestamp) {
+      updater.updateState(timestamp);
+    },
+  });
+
+  const asyncIterable = makeAsyncIterableFromNotifier(notifier);
+
+  /** @type {CancelFunction} */
+  const cancel = (reason = Error(`timerAsyncIterable was cancelled`)) => {
+    updater.fail(reason);
+  };
+
+  return { asyncIterable, cancel };
+};

--- a/api/src/priceAuthority/fake.js
+++ b/api/src/priceAuthority/fake.js
@@ -1,0 +1,81 @@
+// @ts-check
+import { E } from '@agoric/eventual-send';
+import { assert, details } from '@agoric/assert';
+
+import { makeFungiblePriceAuthority } from './fungible';
+import {
+  makeScriptedAsyncIterable,
+  makeRepeaterAsyncIterableKit,
+} from '../asyncIterableKit';
+
+import '@agoric/zoe/exported';
+
+/**
+ * @typedef {Object} FakePriceAuthorityOptions
+ * @property {AmountMath} mathIn
+ * @property {AmountMath} mathOut
+ * @property {Array<number>} [priceList]
+ * @property {Array<[number, number]>} [tradeList]
+ * @property {ERef<TimerService>} timer
+ * @property {RelativeTime} [quoteInterval]
+ * @property {ERef<Mint>} [quoteMint]
+ * @property {Amount} [unitAmountIn]
+ * @property {boolean} [repeat]
+ */
+
+/**
+ * TODO: multiple price Schedules for different goods, or for moving the price
+ * in different directions?
+ *
+ * @param {FakePriceAuthorityOptions} options
+ * @returns {Promise<PriceAuthority>}
+ */
+export async function makeFakePriceAuthority(options) {
+  const {
+    mathIn,
+    mathOut,
+    priceList,
+    tradeList,
+    timer,
+    unitAmountIn = mathIn.make(1),
+    quoteInterval = 1,
+    repeat = true,
+    quoteMint,
+  } = options;
+
+  assert(
+    tradeList || priceList,
+    details`One of priceList or tradeList must be specified`,
+  );
+
+  const unitValueIn = mathIn.getValue(unitAmountIn);
+
+  /** @type {Array<[number, number]>} */
+  const trades = priceList
+    ? priceList.map(price => [unitValueIn, price])
+    : tradeList;
+
+  // Create a repeater for our timer.
+  const repeater = E(timer).createRepeater(0, quoteInterval);
+  const {
+    asyncIterable: repeaterAsyncIterable,
+  } = await makeRepeaterAsyncIterableKit(repeater);
+
+  // Do the trades over the repeater.
+  const quotes = makeScriptedAsyncIterable(
+    trades,
+    repeaterAsyncIterable,
+    timer,
+    repeat,
+  );
+
+  const priceAuthority = await makeFungiblePriceAuthority({
+    mathIn,
+    mathOut,
+    quotes,
+    quoteMint,
+    timer,
+  });
+
+  return priceAuthority;
+}

--- a/api/src/priceAuthority/fungible.js
+++ b/api/src/priceAuthority/fungible.js
@@ -1,0 +1,277 @@
+// @ts-check
+import { makeIssuerKit, MathKind, makeLocalAmountMath } from '@agoric/ertp';
+import { makePromiseKit } from '@agoric/promise-kit';
+import { updateFromIterable, makeNotifierKit } from '@agoric/notifier';
+import { E } from '@agoric/eventual-send';
+import { assert, details } from '@agoric/assert';
+
+import { natSafeMath } from '@agoric/zoe/src/contractSupport';
+
+import '@agoric/zoe/exported';
+
+/**
+ * @typedef {number} ValueIn
+ * @typedef {number} ValueOut
+ * @typedef {AsyncIterable<{ timestamp: Timestamp, timer: TimerService, item: [ValueIn, ValueOut] }>} QuoteStream
+ */
+
+/**
+ * @typedef {Object} FungiblePriceAuthorityOptions
+ * @property {AmountMath} mathIn
+ * @property {AmountMath} mathOut
+ * @property {QuoteStream} quotes
+ * @property {ERef<TimerService>} timer
+ * @property {ERef<Mint>} [quoteMint]
+ */
+
+/**
+ * @param {FungiblePriceAuthorityOptions} options
+ * @returns {Promise<PriceAuthority>}
+ */
+export async function makeFungiblePriceAuthority(options) {
+  const {
+    mathIn,
+    mathOut,
+    quotes,
+    timer: timerP,
+    quoteMint = makeIssuerKit('quote', MathKind.SET).mint,
+  } = options;
+
+  const timer = await timerP;
+
+  /**
+   * @typedef {(a: number, b: number) => boolean} Operator
+   */
+
+  /** @type {Operator} */
+  const isGTE = (a, b) => a >= b;
+  /** @type {Operator} */
+  const isGT = (a, b) => a > b;
+  /** @type {Operator} */
+  const isLTE = (a, b) => a <= b;
+  /** @type {Operator} */
+  const isLT = (a, b) => a < b;
+
+  /**
+   * @typedef {Object} Trigger
+   * @property {Operator} operator
+   * @property {ValueIn} valueIn
+   * @property {ValueOut} valueOutLimit
+   * @property {(quote: PriceQuote) => void} resolve
+   */
+
+  /** @type {Array<Trigger>} */
+  const triggerQueue = [];
+
+  /**
+   * @param {Brand} brandIn
+   * @param {Brand} brandOut
+   */
+  const assertBrands = (brandIn, brandOut) => {
+    assert.equal(
+      brandIn,
+      mathIn.getBrand(),
+      details`${brandIn} is not an expected input brand`,
+    );
+    assert.equal(
+      brandOut,
+      mathOut.getBrand(),
+      details`${brandOut} is not an expected output brand`,
+    );
+  };
+
+  const quoteIssuer = E(quoteMint).getIssuer();
+  const quoteMath = await makeLocalAmountMath(quoteIssuer);
+
+  /** @type {NotifierRecord<PriceQuote>} */
+  const { notifier, updater } = makeNotifierKit();
+
+  /**
+   * @param {ValueIn} valueIn
+   * @param {ValueOut} valueOut
+   * @param {Timestamp} quoteTime
+   * @returns {PriceQuote}
+   */
+  const makeQuote = (valueIn, valueOut, quoteTime) => {
+    const quoteAmount = quoteMath.make(
+      harden([
+        {
+          amountIn: mathIn.make(valueIn),
+          amountOut: mathOut.make(valueOut),
+          timer,
+          timestamp: quoteTime,
+        },
+      ]),
+    );
+    const quote = harden({
+      quotePayment: E(quoteMint).mintPayment(quoteAmount),
+      quoteAmount,
+    });
+    return quote;
+  };
+
+  /** @type {PriceQuote} */
+  let latestQuote;
+
+  /** @type {ValueIn} */
+  let latestValueIn;
+
+  /** @type {ValueOut} */
+  let latestValueOut;
+
+  /**
+   * See which triggers have fired.
+   *
+   * @param {Timestamp} timestamp
+   */
+  const checkTriggers = timestamp => {
+    let i = 0;
+    while (i < triggerQueue.length) {
+      const { valueIn, operator, resolve, valueOutLimit } = triggerQueue[i];
+      const valueOut = natSafeMath.floorDivide(
+        natSafeMath.multiply(valueIn, latestValueOut),
+        latestValueIn,
+      );
+
+      if (operator(valueOut, valueOutLimit)) {
+        // Fire the trigger!
+        triggerQueue.splice(i, 1);
+        resolve(makeQuote(valueIn, valueOut, timestamp));
+      } else {
+        i += 1;
+      }
+    }
+  };
+
+  /** Update from the latest quote. */
+  updateFromIterable(
+    {
+      async finish(_ignore) {
+        updater.finish(latestQuote);
+      },
+      fail(reason) {
+        if (latestQuote) {
+          // We don't fail the updater, just finish with the latest state.
+          updater.finish(latestQuote);
+        }
+        // Failed to produce any values.
+        updater.fail(reason);
+      },
+      updateState({ timestamp, item: [valueIn, valueOut] }) {
+        latestQuote = makeQuote(valueIn, valueOut, timestamp);
+        latestValueIn = valueIn;
+        latestValueOut = valueOut;
+        updater.updateState(latestQuote);
+
+        // Check the triggers with the new quote.
+        checkTriggers(timestamp);
+      },
+    },
+    quotes,
+  );
+
+  /**
+   * Get a quote for at most the given amountIn
+   *
+   * @param {Amount} amountIn
+   * @param {Brand} brandOut
+   * @param {Timestamp} quoteTime
+   * @returns {PriceQuote}
+   */
+  function quoteGivenAtMost(amountIn, brandOut, quoteTime) {
+    assertBrands(amountIn.brand, brandOut);
+    const valueIn = mathIn.getValue(amountIn);
+    const valueOut = natSafeMath.floorDivide(
+      natSafeMath.multiply(amountIn.value, latestValueOut),
+      latestValueIn,
+    );
+    return makeQuote(valueIn, valueOut, quoteTime);
+  }
+
+  /**
+   * Get a quote for at least the given amountOut.
+   *
+   * @param {Brand} brandIn
+   * @param {Amount} amountOut
+   * @param {Timestamp} quoteTime
+   * @returns {PriceQuote}
+   */
+  function quoteWantedAtLeast(brandIn, amountOut, quoteTime) {
+    assertBrands(brandIn, amountOut.brand);
+    const valueOut = mathOut.getValue(amountOut);
+    const valueIn = natSafeMath.ceilDivide(
+      natSafeMath.multiply(valueOut, latestValueIn),
+      latestValueOut,
+    );
+    return quoteGivenAtMost(mathIn.make(valueIn), amountOut.brand, quoteTime);
+  }
+
+  function resolveQuoteWhen(operator, amountIn, amountOutLimit) {
+    assertBrands(amountIn.brand, amountOutLimit.brand);
+    const promiseKit = makePromiseKit();
+    triggerQueue.push({
+      operator,
+      valueIn: mathIn.getValue(amountIn),
+      valueOutLimit: mathOut.getValue(amountOutLimit),
+      resolve: promiseKit.resolve,
+    });
+    return promiseKit.promise;
+  }
+
+  /** @type {PriceAuthority} */
+  const priceAuthority = {
+    async getQuoteIssuer(brandIn, brandOut) {
+      assertBrands(brandIn, brandOut);
+      return quoteIssuer;
+    },
+    async getTimerService(brandIn, brandOut) {
+      assertBrands(brandIn, brandOut);
+      return timer;
+    },
+    async getQuoteNotifier(brandIn, brandOut) {
+      assertBrands(brandIn, brandOut);
+      return notifier;
+    },
+    async quoteAtTime(timeStamp, amountIn, brandOut) {
+      assertBrands(amountIn.brand, brandOut);
+      const { promise, resolve } = makePromiseKit();
+      E(timer).setWakeup(
+        timeStamp,
+        harden({
+          wake: time => {
+            return resolve(quoteGivenAtMost(amountIn, brandOut, time));
+          },
+        }),
+      );
+      return promise;
+    },
+    async quoteGiven(amountIn, brandOut) {
+      assertBrands(amountIn.brand, brandOut);
+      const timestamp = await E(timer).getCurrentTimestamp();
+      return quoteGivenAtMost(amountIn, brandOut, timestamp);
+    },
+    async quoteWanted(brandIn, amountOut) {
+      assertBrands(brandIn, amountOut.brand);
+      const timestamp = await E(timer).getCurrentTimestamp();
+      return quoteWantedAtLeast(brandIn, amountOut, timestamp);
+    },
+    async quoteWhenGTE(amountIn, amountOutLimit) {
+      return resolveQuoteWhen(isGTE, amountIn, amountOutLimit);
+    },
+    async quoteWhenGT(amountIn, amountOutLimit) {
+      return resolveQuoteWhen(isGT, amountIn, amountOutLimit);
+    },
+    async quoteWhenLTE(amountIn, amountOutLimit) {
+      return resolveQuoteWhen(isLTE, amountIn, amountOutLimit);
+    },
+    async quoteWhenLT(amountIn, amountOutLimit) {
+      return resolveQuoteWhen(isLT, amountIn, amountOutLimit);
+    },
+  };
+
+  // Wait for the first quote.  This is essential so that there is at least one
+  // quote to base the others on.
+  await notifier.getUpdateSince();
+
+  return priceAuthority;
+}

--- a/api/src/priceAuthority/index.js
+++ b/api/src/priceAuthority/index.js
@@ -1,0 +1,3 @@
+export * from './fake';
+export * from './fungible';
+export * from './registry';

--- a/api/src/priceAuthority/registry.js
+++ b/api/src/priceAuthority/registry.js
@@ -1,0 +1,153 @@
+// @ts-check
+
+import { E } from '@agoric/eventual-send';
+import { makeStore } from '@agoric/store';
+import { assert, details } from '@agoric/assert';
+
+import '@agoric/zoe/exported';
+
+/**
+ * @typedef {Object} Deleter
+ * @property {() => void} delete
+ */
+
+/**
+ * @typedef {Object} PriceAuthorityRegistryAdmin
+ * @property {(pa: ERef<PriceAuthority>, brandIn: Brand, brandOut: Brand, force:
+ * boolean | undefined)
+ * => Deleter} registerPriceAuthority Add a unique price authority for a given
+ * pair
+ */
+
+/**
+ * @typedef {Object} PriceAuthorityRegistry A price authority that is a facade
+ * for other backing price authorities registered for a given asset and price
+ * brand
+ * @property {PriceAuthority} priceAuthority
+ * @property {PriceAuthorityRegistryAdmin} adminFacet
+ */
+
+/**
+ * @returns {PriceAuthorityRegistry}
+ */
+export const makePriceAuthorityRegistry = () => {
+  /**
+   * @typedef {Object} PriceAuthorityRecord A record indicating a registered
+   * price authority.  We put a box around the priceAuthority to ensure the
+   * deleter doesn't delete the wrong thing.
+   * @property {ERef<PriceAuthority>} priceAuthority the sub-authority for a
+   * given input and output brand pair
+   */
+
+  /** @type {Store<Brand, Store<Brand, PriceAuthorityRecord>>} */
+  const assetToPriceStore = makeStore('brandIn');
+
+  /**
+   * Get the registered price authority for a given input and output pair.
+   *
+   * @param {Brand} brandIn
+   * @param {Brand} brandOut
+   * @returns {ERef<PriceAuthority>}
+   */
+  const paFor = (brandIn, brandOut) => {
+    const priceStore = assetToPriceStore.get(brandIn);
+    return priceStore.get(brandOut).priceAuthority;
+  };
+
+  /**
+   * Create a quoteWhen* method for the given condition.
+   *
+   * @param {'LT' | 'LTE' | 'GTE' | 'GT'} relation
+   */
+  const makeQuoteWhen = relation =>
+    /**
+     * Return a quote when relation is true of the arguments.
+     *
+     * @param {Amount} amountIn monitor the amountOut corresponding to this amountIn
+     * @param {Amount} amountOutLimit the value to compare with the monitored amountOut
+     * @returns {Promise<PriceQuote>} resolve with a quote when `amountOut
+     * relation amountOutLimit` is true
+     */
+    async function quoteWhenRelation(amountIn, amountOutLimit) {
+      const pa = paFor(amountIn.brand, amountOutLimit.brand);
+      return E(pa)[`quoteWhen${relation}`](amountIn, amountOutLimit);
+    };
+
+  /**
+   * This PriceAuthority is just a wrapper for multiple registered
+   * PriceAuthorities.
+   *
+   * @type {PriceAuthority}
+   */
+  const priceAuthority = {
+    async getQuoteIssuer(brandIn, brandOut) {
+      return E(paFor(brandIn, brandOut)).getQuoteIssuer(brandIn, brandOut);
+    },
+    async getTimerService(brandIn, brandOut) {
+      return E(paFor(brandIn, brandOut)).getTimerService(brandIn, brandOut);
+    },
+    async quoteGiven(amountIn, brandOut) {
+      return E(paFor(amountIn.brand, brandOut)).quoteGiven(amountIn, brandOut);
+    },
+    async quoteWanted(brandIn, amountOut) {
+      return E(paFor(brandIn, amountOut.brand)).quoteWanted(brandIn, amountOut);
+    },
+    async getQuoteNotifier(brandIn, brandOut) {
+      return E(paFor(brandIn, brandOut)).getQuoteNotifier(brandIn, brandOut);
+    },
+    async quoteAtTime(deadline, amountIn, brandOut) {
+      return E(paFor(amountIn.brand, brandOut)).quoteAtTime(
+        deadline,
+        amountIn,
+        brandOut,
+      );
+    },
+    quoteWhenLT: makeQuoteWhen('LT'),
+    quoteWhenLTE: makeQuoteWhen('LTE'),
+    quoteWhenGTE: makeQuoteWhen('GTE'),
+    quoteWhenGT: makeQuoteWhen('GT'),
+  };
+
+  /** @type {PriceAuthorityRegistryAdmin} */
+  const adminFacet = {
+    registerPriceAuthority(pa, brandIn, brandOut, force = false) {
+      /** @type {Store<Brand, PriceAuthorityRecord>} */
+      let priceStore;
+      if (assetToPriceStore.has(brandIn)) {
+        priceStore = assetToPriceStore.get(brandIn);
+      } else {
+        priceStore = makeStore('brandOut');
+        assetToPriceStore.init(brandIn, priceStore);
+      }
+
+      // Put a box around the authority so that we can be ensured the deleter
+      // won't delete the wrong thing.
+      const record = {
+        priceAuthority: pa,
+      };
+
+      // Set up the record.
+      if (force && priceStore.has(brandOut)) {
+        priceStore.set(brandOut, harden(record));
+      } else {
+        priceStore.init(brandOut, harden(record));
+      }
+
+      return harden({
+        delete() {
+          assert.equal(
+            priceStore.has(brandOut) && priceStore.get(brandOut),
+            record,
+            details`Price authority already dropped`,
+          );
+          priceStore.delete(brandOut);
+        },
+      });
+    },
+  };
+
+  return harden({
+    priceAuthority,
+    adminFacet,
+  });
+};

--- a/api/src/priceAuthorityFactory.js
+++ b/api/src/priceAuthorityFactory.js
@@ -1,0 +1,57 @@
+// @ts-check
+import { E } from '@agoric/eventual-send';
+import { makeLocalAmountMath } from '@agoric/ertp';
+import { makeFungiblePriceAuthority } from '@agoric/zoe/src/contracts/priceAuthority';
+import { makeAsyncIterableFromNotifier } from '@agoric/notifier';
+
+const startSpawn = async (_terms, _invitationMaker) => {
+  const factory = {
+    async makeNotifierPriceAuthority({
+      notifier,
+      issuerIn,
+      issuerOut,
+      timer,
+      unitValueIn = 1,
+      quoteMint,
+    }) {
+      const [mathIn, mathOut] = await Promise.all([
+        makeLocalAmountMath(issuerIn),
+        makeLocalAmountMath(issuerOut),
+      ]);
+      mathIn.make(unitValueIn);
+
+      async function* makeQuotes() {
+        for await (const sample of makeAsyncIterableFromNotifier(notifier)) {
+          /** @type {number} */
+          let valueOutForUnitIn;
+          try {
+            valueOutForUnitIn = parseInt(sample, 10);
+            mathOut.make(valueOutForUnitIn);
+          } catch (e) {
+            console.error(`Cannot parse ${JSON.stringify(sample)}:`, e);
+            // eslint-disable-next-line no-continue
+            continue;
+          }
+          const timestamp = await E(timer).getCurrentTimestamp();
+          /** @type {[number, number]} */
+          const item = [unitValueIn, valueOutForUnitIn];
+          const quote = { timestamp, timer, item };
+          // console.error('quoting', quote);
+          yield quote;
+        }
+      }
+
+      const quotes = makeQuotes();
+      return makeFungiblePriceAuthority({
+        mathIn,
+        mathOut,
+        quotes,
+        timer,
+        quoteMint,
+      });
+    },
+  };
+  return harden(factory);
+};
+
+export default harden(startSpawn);

--- a/api/src/priceAuthorityFactory.js
+++ b/api/src/priceAuthorityFactory.js
@@ -1,8 +1,8 @@
 // @ts-check
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
-import { makeFungiblePriceAuthority } from '@agoric/zoe/src/contracts/priceAuthority';
 import { makeAsyncIterableFromNotifier } from '@agoric/notifier';
+import { makeFungiblePriceAuthority } from './priceAuthority';
 
 const startSpawn = async (_terms, _invitationMaker) => {
   const factory = {

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -43,8 +43,6 @@
 </textarea><br/>
       <div class="queryButtons"><input type="submit" value="Query Oracle!" id="queryOracle"
       disabled="disabled" />
-      <input class="visibleOnlyToOracleService" type="submit" value="Create Notifier"
-       id="createNotifier" disabled="disabled" />
       <iframe id="walletBridgeIFrame" width="100" height="21"></iframe></div>
     </form>
 
@@ -57,6 +55,8 @@
     <p>This oracle can be reached at: <span
     id="myOracleInstanceId">loading...</span></p>
  
+    <input type="submit" value="Create Push Query" id="createNotifier" disabled="disabled" />
+
     <ul id="oracleRequests">
     </ul>
 

--- a/ui/public/src/main.js
+++ b/ui/public/src/main.js
@@ -74,7 +74,7 @@ export default async function main() {
               return 1;
             }
             return 0;
-          }).map(([_key, data]) => data).forEach(processPendingQueryData);
+          }).map(([_key, data]) => data || {}).forEach(processPendingQueryData);
           break;
         }
         case 'oracleServer/createNotifierResponse': {
@@ -89,19 +89,8 @@ export default async function main() {
   const $createNotifier = document.getElementById('createNotifier');
   if ($createNotifier) {
     $createNotifier.addEventListener('click', ev => {
-      let query;
-      try {
-        query = JSON5.parse($oracleQuery.value);
-        if (Object(query) !== query) {
-          throw Error(`Not a JSON object`);
-        }
-      } catch (e) {
-        alert(`Query is invalid: ${e}`);
-        return;
-      }
       oracleSend({
         type: 'oracleServer/createNotifier',
-        data: { query, fee: 0 },
       });
     });
     $createNotifier.removeAttribute('disabled');
@@ -114,6 +103,7 @@ export default async function main() {
       return;
     }
     const el = document.createElement('li');
+    el.classList.add(qid);
     if (queryId.startsWith('push-')) {
       const notifier = document.createElement('div');
       const boardId = notifiers.get(queryId);
@@ -123,9 +113,8 @@ Notifier: <span id="notifier-${queryId}">${display}</span>
 `;
       el.appendChild(notifier);
     }
-    el.classList.add(qid);
     $oracleRequests.appendChild(el);
-    if (!el.querySelector('.query')) {
+    if (!queryId.startsWith('push-') && !el.querySelector('.query')) {
       const ql = document.createElement('code');
       ql.innerText = JSON.stringify(query, null, 2);
       ql.setAttribute('class', 'query');
@@ -139,6 +128,7 @@ Notifier: <span id="notifier-${queryId}">${display}</span>
     }
     if (queryId.startsWith('push-')) {
       actions.innerHTML = `\
+request_id: ${JSON.stringify(queryId)}<br />
 <textarea placeholder="JSON push">null</textarea><br />
 <button class="push">Push</button> <button class="cancel">Cancel</button>
 `;


### PR DESCRIPTION
This is the glue code needed to have `agoric.priceAuthority` use an external oracle.  No changes to the on-chain code or the external oracle contract were needed.
