### PR TITLE
chore: Patch RESM for emigration

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
     steps:
     - name: Checkout dapp-encouragement
       uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "agoric": "*",
     "babel-eslint": ">=11.0.0-beta.2",
     "eslint-plugin-eslint-comments": "^3.1.2"
+  },
+  "resolutions": {
+    "**/esm": "agoric-labs/esm#Agoric-built"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2182,10 +2182,9 @@ eslint@^6.1.0, eslint@^6.8.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esm@^3.2.25, esm@^3.2.5:
+esm@^3.2.25, esm@^3.2.5, esm@agoric-labs/esm#Agoric-built:
   version "3.2.25"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
-  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+  resolved "https://codeload.github.com/agoric-labs/esm/tar.gz/3603726ad4636b2f865f463188fcaade6375638e"
 
 espree@^6.1.2:
   version "6.2.1"


### PR DESCRIPTION
This change will allow dependencies in Agoric SDK to begin migrating away from
`node -r esm`.
