### PR TITLE
fix: Add language hint for Endo archive generator

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.1.0",
   "description": "dapp-oracle Agoric Dapp web server handler",
+  "parsers": {
+    "js": "mjs"
+  },
   "scripts": {
     "build": "exit 0",
     "test": "ava",

--- a/contract/package.json
+++ b/contract/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "description": "Contract for the dapp-oracle Agoric Dapp",
+  "parsers": {
+    "js": "mjs"
+  },
   "scripts": {
     "build": "exit 0",
     "test": "ava --verbose",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "useWorkspaces": true,
   "main": "index.js",
+  "parsers": {
+    "js": "mjs"
+  },
   "workspaces": [
     "api",
     "contract",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,9 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "homepage": ".",
+  "parsers": {
+    "js": "mjs"
+  },
   "scripts": {
     "build": "parcel build public/index.html",
     "lint-check": "eslint '**/*.{js,jsx}'",


### PR DESCRIPTION
This adds a parsers declaration to package.json, which Endo's compartment mapper recognizes that a `.js` file is a JavaScript module and not a CommonJS module, but unlike `"type": "module"`, does not confuse `node -r esm`.
