### PR TITLE
fix(flux): send prices as branded ratios

### DIFF
--- a/api/spawn.js
+++ b/api/spawn.js
@@ -139,6 +139,9 @@ export default async function spawnOracle(
   // in the shutdown.js script).
   await E(scratch).set('oracleMaster', oracleMaster);
 
+  const replaceableNotifiers = await E(oracleMaster).makeReplaceableNotifiers();
+  await E(scratch).set('replaceableNotifiers', replaceableNotifiers);
+
   console.log('Retrieving Board IDs for issuers and brands');
   const invitationBrandP = E(invitationIssuer).getBrand();
 

--- a/api/src/core-proposal.js
+++ b/api/src/core-proposal.js
@@ -19,7 +19,6 @@ export const getManifestForPriceFeed = async ({ restoreRef }, options) => ({
       },
       produce: { aggregators: t },
       instance: { produce: { [options.AGORIC_INSTANCE_NAME]: t } },
-      installation: { consume: { priceAggregator: t } },
     },
     ensureOracleBrands: {
       consume: {
@@ -101,9 +100,6 @@ export const createPriceFeed = async (
     },
     produce: { aggregators: produceAggregators },
     instance: { produce: instanceProduce },
-    installation: {
-      consume: { priceAggregator },
-    },
   },
   {
     options: {
@@ -121,10 +117,15 @@ export const createPriceFeed = async (
 
   const timer = await chainTimerService;
 
-  const [brandIn, brandOut] = await reserveThenGetNames(
-    E(agoricNamesAdmin).lookupAdmin('oracleBrand'),
-    [IN_BRAND_NAME, OUT_BRAND_NAME],
-  );
+  const [[brandIn, brandOut], [priceAggregator]] = await Promise.all([
+    reserveThenGetNames(E(agoricNamesAdmin).lookupAdmin('oracleBrand'), [
+      IN_BRAND_NAME,
+      OUT_BRAND_NAME,
+    ]),
+    reserveThenGetNames(E(agoricNamesAdmin).lookupAdmin('installation'), [
+      'priceAggregator',
+    ]),
+  ]);
 
   const terms = {
     ...contractTerms,

--- a/api/src/handler.js
+++ b/api/src/handler.js
@@ -6,6 +6,7 @@ import { makeExternalOracle } from './external.js';
 import { makeBuiltinOracle } from './builtin.js';
 // import { makeCronTickIterable } from './cron.js';
 import { makeFluxNotifier } from './flux.js';
+import { makeReplaceableNotifiers } from './notifier.js';
 import { makePeriodicTickIterable } from './ticks.js';
 
 /**
@@ -116,6 +117,7 @@ const startSpawn = async (
         });
       },
       makeFluxNotifier,
+      makeReplaceableNotifiers,
       /**
        *
        * @param {AsyncIterable<bigint>} tickIterable

--- a/api/src/notifier.js
+++ b/api/src/notifier.js
@@ -1,0 +1,97 @@
+// @ts-check
+import { E, Far } from '@agoric/far';
+import { makeLegacyMap } from '@agoric/store';
+import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
+
+export const makeReplaceableNotifiers = () => {
+  const LEAF_KEY = Far('leaf key', {});
+  const rootMap = makeLegacyMap();
+  return Far('replaceable notifiers', {
+    delete: keyPath => {
+      let map = rootMap;
+      for (const key of keyPath) {
+        if (!map.has(key)) {
+          throw new Error(`No such key: ${key}`);
+        }
+        map = map.get(key);
+      }
+      if (!map.has(LEAF_KEY)) {
+        throw new Error(`No such leaf key: ${keyPath}`);
+      }
+      const { metaUpdater } = map.get(LEAF_KEY);
+      map.delete(LEAF_KEY);
+      metaUpdater.finish();
+    },
+    replace: (keyPath, notifier) => {
+      let map = rootMap;
+      for (const key of keyPath) {
+        if (!map.has(key)) {
+          map.init(key, makeLegacyMap('key'));
+        }
+        map = map.get(key);
+      }
+      if (!map.has(LEAF_KEY)) {
+        /** @type {NotifierRecord<unknown>} */
+        const {
+          updater: stableUpdater,
+          notifier: stableNotifier,
+        } = makeNotifierKit();
+        /** @type {NotifierRecord<Notifier<unknown>>} */
+        const {
+          updater: metaUpdater,
+          notifier: metaNotifier,
+        } = makeNotifierKit();
+
+        /** @type {Notifier<unknown> | undefined} */
+        let currentNotifier;
+        let finishing = false;
+        /**
+         * @param {Notifier<unknown>} thisNotifier
+         * @param {number} [startCount]
+         */
+        const updateWhileCurrent = async (thisNotifier, startCount) => {
+          // Wait until this notifier produces a new value.
+          const { value, updateCount: nextCount } = await E(thisNotifier)
+            .getUpdateSince(startCount)
+            .catch(e => {
+              console.error(thisNotifier, 'failed with', e);
+              currentNotifier = undefined;
+              return { value: undefined, updateCount: NaN };
+            });
+          if (thisNotifier !== currentNotifier) {
+            // Terminate the recursion; we're no longer the current notifier.
+            return;
+          }
+          // Update the stable notifier.
+          if (finishing) {
+            stableUpdater.finish(value);
+            currentNotifier = undefined;
+          } else {
+            stableUpdater.updateState(value);
+            updateWhileCurrent(thisNotifier, nextCount);
+          }
+        };
+
+        // Observe our notifier of notifiers.
+        observeNotifier(metaNotifier, {
+          fail: e => {
+            currentNotifier = undefined;
+            stableUpdater.fail(e);
+          },
+          finish: () => {
+            finishing = true;
+          },
+          updateState: newNotifier => {
+            currentNotifier = newNotifier;
+            updateWhileCurrent(newNotifier);
+          },
+        });
+
+        map.init(LEAF_KEY, harden({ metaUpdater, stableNotifier }));
+      }
+      const { metaUpdater, stableNotifier } = map.get(LEAF_KEY);
+      metaUpdater.updateState(notifier);
+      return stableNotifier;
+    },
+  });
+};


### PR DESCRIPTION
Must be used in conjunction with Agoric/agoric-sdk#5264

This improves the reliability of the flux notifier:
- reduce price roundoff errors by using ratios, and implement scaling in the notifier rather than as an argument to the aggregator
- provide a consistent notifier identity, which represents the latest flux notifier.  This allows changing notifier parameters without having to reregister with the aggregator
 