### PR TITLE
fix(docker-compose): mount statedir at `/data/solo` so the solo persists

### DIFF
--- a/chainlink-agoric/docker-compose.yml
+++ b/chainlink-agoric/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - "DEBUG=SwingSet:vat,SwingSet:ls"
     volumes:
       - 'ag1:/usr/src/app/solo'
+      - 'ag1:/data/solo'
       - '$HOME/.agoric:/root/.agoric'
       - '..:/usr/src/dapp-oracle'
   external-initiator-node1:
@@ -104,6 +105,7 @@ services:
       - "DEBUG=SwingSet:vat,SwingSet:ls"
     volumes:
       - 'ag2:/usr/src/app/solo'
+      - 'ag2:/data/solo'
       - '$HOME/.agoric:/root/.agoric'
       - '..:/usr/src/dapp-oracle'
   external-initiator-node2:
@@ -149,6 +151,7 @@ services:
       - "DEBUG=SwingSet:vat,SwingSet:ls"
     volumes:
       - 'ag3:/usr/src/app/solo'
+      - 'ag3:/data/solo'
       - '$HOME/.agoric:/root/.agoric'
       - '..:/usr/src/dapp-oracle'
   external-initiator-node3:


### PR DESCRIPTION
This is a critical fix to prevent `docker-compose down` from losing all of the `ag-solo`'s state in recent `agoric/cosmic-swingset-solo` Docker images.

The statedir was moved to `/data/solo` in the `agoric-sdk` build, and we didn't correctly update `dapp-oracle`.
